### PR TITLE
feat: add Q_wad and Q_ray spec-only fixed-point types

### DIFF
--- a/crates/sui-framework/packages/move-stdlib/sources/integer.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/integer.move
@@ -38,6 +38,10 @@ public use fun std::q32::from_integer as Integer.to_q32;
 public use fun std::q64::from_integer as Integer.to_q64;
 #[spec_only]
 public use fun std::q128::from_integer as Integer.to_q128;
+#[spec_only]
+public use fun std::q_wad::from_integer as Integer.to_q_wad;
+#[spec_only]
+public use fun std::q_ray::from_integer as Integer.to_q_ray;
 
 #[spec_only]
 native public fun add(x: Integer, y: Integer): Integer;

--- a/crates/sui-framework/packages/move-stdlib/sources/q_ray.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/q_ray.move
@@ -1,0 +1,189 @@
+/// Signed fixed-point type with 27 decimal fractional digits (RAY).
+/// Internally stores an arbitrary-precision `Integer`; actual value = val / 10^27.
+module std::q_ray;
+
+#[spec_only]
+use std::integer::Integer;
+#[spec_only]
+use std::real::Real;
+
+#[spec_only]
+const SCALE: u128 = 1_000_000_000_000_000_000_000_000_000;
+#[spec_only]
+const HALF_SCALE: u128 = 500_000_000_000_000_000_000_000_000;
+
+#[spec_only]
+public struct Q_ray has copy, drop, store { val: Integer }
+
+// === Construction ===
+
+#[spec_only, ext(pure)]
+public fun from_integer(x: Integer): Q_ray {
+    Q_ray { val: x.mul(SCALE.to_int()) }
+}
+
+#[spec_only, ext(pure)]
+public fun from_u8(x: u8): Q_ray { from_integer(x.to_int()) }
+#[spec_only, ext(pure)]
+public fun from_u16(x: u16): Q_ray { from_integer(x.to_int()) }
+#[spec_only, ext(pure)]
+public fun from_u32(x: u32): Q_ray { from_integer(x.to_int()) }
+#[spec_only, ext(pure)]
+public fun from_u64(x: u64): Q_ray { from_integer(x.to_int()) }
+#[spec_only, ext(pure)]
+public fun from_u128(x: u128): Q_ray { from_integer(x.to_int()) }
+#[spec_only, ext(pure)]
+public fun from_u256(x: u256): Q_ray { from_integer(x.to_int()) }
+
+#[spec_only, ext(pure)]
+public fun from_real(x: Real): Q_ray {
+    Q_ray { val: x.mul(SCALE.to_real()).to_integer() }
+}
+
+#[spec_only]
+public macro fun zero(): Q_ray {
+    Q_ray { val: std::integer::zero!() }
+}
+
+#[spec_only]
+public macro fun one(): Q_ray {
+    from_integer(std::integer::one!())
+}
+
+#[spec_only, ext(pure)]
+public fun quot(num: Integer, den: Integer): Q_ray {
+    Q_ray { val: num.mul(SCALE.to_int()).div(den) }
+}
+
+// === Accessors ===
+
+#[spec_only, ext(pure)]
+public fun raw(q: Q_ray): Integer { q.val }
+
+#[spec_only, ext(pure)]
+public fun from_raw(val: Integer): Q_ray { Q_ray { val } }
+
+// === Arithmetic ===
+
+#[spec_only, ext(pure)]
+public fun add(a: Q_ray, b: Q_ray): Q_ray {
+    Q_ray { val: a.val.add(b.val) }
+}
+
+#[spec_only, ext(pure)]
+public fun sub(a: Q_ray, b: Q_ray): Q_ray {
+    Q_ray { val: a.val.sub(b.val) }
+}
+
+#[spec_only, ext(pure)]
+public fun mul(a: Q_ray, b: Q_ray): Q_ray {
+    Q_ray { val: a.val.mul(b.val).div(SCALE.to_int()) }
+}
+
+#[spec_only, ext(pure)]
+public fun div(a: Q_ray, b: Q_ray): Q_ray {
+    Q_ray { val: a.val.mul(SCALE.to_int()).div(b.val) }
+}
+
+#[spec_only, ext(pure)]
+public fun neg(a: Q_ray): Q_ray {
+    Q_ray { val: a.val.neg() }
+}
+
+#[spec_only, ext(pure)]
+public fun abs(a: Q_ray): Q_ray {
+    Q_ray { val: a.val.abs() }
+}
+
+#[spec_only, ext(pure)]
+public fun sqrt(a: Q_ray): Q_ray {
+    Q_ray { val: a.val.mul(SCALE.to_int()).sqrt() }
+}
+
+#[spec_only, ext(pure)]
+public fun pow(x: Q_ray, n: Integer): Q_ray {
+    Q_ray { val: std::macros::q_pow!(x.val, n, SCALE.to_int()) }
+}
+
+// === Comparisons ===
+
+#[spec_only, ext(pure)]
+public fun lt(a: Q_ray, b: Q_ray): bool { a.val.lt(b.val) }
+
+#[spec_only, ext(pure)]
+public fun gt(a: Q_ray, b: Q_ray): bool { a.val.gt(b.val) }
+
+#[spec_only, ext(pure)]
+public fun lte(a: Q_ray, b: Q_ray): bool { a.val.lte(b.val) }
+
+#[spec_only, ext(pure)]
+public fun gte(a: Q_ray, b: Q_ray): bool { a.val.gte(b.val) }
+
+#[spec_only, ext(pure)]
+public fun min(a: Q_ray, b: Q_ray): Q_ray {
+    if (a.lt(b)) a else b
+}
+
+#[spec_only, ext(pure)]
+public fun max(a: Q_ray, b: Q_ray): Q_ray {
+    if (a.gt(b)) a else b
+}
+
+// === Rounding / Conversion ===
+
+#[spec_only, ext(pure)]
+public fun floor(q: Q_ray): Integer {
+    q.val.div(SCALE.to_int())
+}
+
+#[spec_only, ext(pure)]
+public fun ceil(q: Q_ray): Integer {
+    q.val.div_round_up(SCALE.to_int())
+}
+
+#[spec_only, ext(pure)]
+public fun round(q: Q_ray): Integer {
+    q.val.add(HALF_SCALE.to_int()).div(SCALE.to_int())
+}
+
+#[spec_only, ext(pure)]
+public fun to_int(q: Q_ray): Integer { floor(q) }
+
+#[spec_only, ext(pure)]
+public fun to_real(q: Q_ray): Real {
+    q.val.to_real().div(SCALE.to_real())
+}
+
+// === Predicates ===
+
+#[spec_only]
+public macro fun is_zero($q: Q_ray): bool {
+    let q = $q;
+    q.val == std::integer::zero!()
+}
+
+#[spec_only, ext(pure)]
+public fun is_pos(q: Q_ray): bool { q.val.is_pos() }
+
+#[spec_only, ext(pure)]
+public fun is_neg(q: Q_ray): bool { q.val.is_neg() }
+
+#[spec_only, ext(pure)]
+public fun is_int(q: Q_ray): bool {
+    q.val.mod(SCALE.to_int()) == 0u128.to_int()
+}
+
+#[spec_only, ext(pure)]
+public fun in_range_u128(x: Q_ray): bool {
+    !x.is_neg() && x.val.lte(
+        0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFFu128.to_int(),
+    )
+}
+
+#[spec_only, ext(pure)]
+public fun in_range_u256(x: Q_ray): bool {
+    !x.is_neg() && x.val.lte(
+        0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFFu256
+            .to_int(),
+    )
+}

--- a/crates/sui-framework/packages/move-stdlib/sources/q_wad.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/q_wad.move
@@ -1,0 +1,194 @@
+/// Signed fixed-point type with 18 decimal fractional digits (WAD).
+/// Internally stores an arbitrary-precision `Integer`; actual value = val / 10^18.
+module std::q_wad;
+
+#[spec_only]
+use std::integer::Integer;
+#[spec_only]
+use std::real::Real;
+
+#[spec_only]
+const SCALE: u64 = 1_000_000_000_000_000_000;
+#[spec_only]
+const HALF_SCALE: u64 = 500_000_000_000_000_000;
+
+#[spec_only]
+public struct Q_wad has copy, drop, store { val: Integer }
+
+// === Construction ===
+
+#[spec_only, ext(pure)]
+public fun from_integer(x: Integer): Q_wad {
+    Q_wad { val: x.mul(SCALE.to_int()) }
+}
+
+#[spec_only, ext(pure)]
+public fun from_u8(x: u8): Q_wad { from_integer(x.to_int()) }
+#[spec_only, ext(pure)]
+public fun from_u16(x: u16): Q_wad { from_integer(x.to_int()) }
+#[spec_only, ext(pure)]
+public fun from_u32(x: u32): Q_wad { from_integer(x.to_int()) }
+#[spec_only, ext(pure)]
+public fun from_u64(x: u64): Q_wad { from_integer(x.to_int()) }
+#[spec_only, ext(pure)]
+public fun from_u128(x: u128): Q_wad { from_integer(x.to_int()) }
+#[spec_only, ext(pure)]
+public fun from_u256(x: u256): Q_wad { from_integer(x.to_int()) }
+
+#[spec_only, ext(pure)]
+public fun from_real(x: Real): Q_wad {
+    Q_wad { val: x.mul(SCALE.to_real()).to_integer() }
+}
+
+#[spec_only]
+public macro fun zero(): Q_wad {
+    Q_wad { val: std::integer::zero!() }
+}
+
+#[spec_only]
+public macro fun one(): Q_wad {
+    from_integer(std::integer::one!())
+}
+
+#[spec_only, ext(pure)]
+public fun quot(num: Integer, den: Integer): Q_wad {
+    Q_wad { val: num.mul(SCALE.to_int()).div(den) }
+}
+
+// === Accessors ===
+
+#[spec_only, ext(pure)]
+public fun raw(q: Q_wad): Integer { q.val }
+
+#[spec_only, ext(pure)]
+public fun from_raw(val: Integer): Q_wad { Q_wad { val } }
+
+// === Arithmetic ===
+
+#[spec_only, ext(pure)]
+public fun add(a: Q_wad, b: Q_wad): Q_wad {
+    Q_wad { val: a.val.add(b.val) }
+}
+
+#[spec_only, ext(pure)]
+public fun sub(a: Q_wad, b: Q_wad): Q_wad {
+    Q_wad { val: a.val.sub(b.val) }
+}
+
+#[spec_only, ext(pure)]
+public fun mul(a: Q_wad, b: Q_wad): Q_wad {
+    Q_wad { val: a.val.mul(b.val).div(SCALE.to_int()) }
+}
+
+#[spec_only, ext(pure)]
+public fun div(a: Q_wad, b: Q_wad): Q_wad {
+    Q_wad { val: a.val.mul(SCALE.to_int()).div(b.val) }
+}
+
+#[spec_only, ext(pure)]
+public fun neg(a: Q_wad): Q_wad {
+    Q_wad { val: a.val.neg() }
+}
+
+#[spec_only, ext(pure)]
+public fun abs(a: Q_wad): Q_wad {
+    Q_wad { val: a.val.abs() }
+}
+
+#[spec_only, ext(pure)]
+public fun sqrt(a: Q_wad): Q_wad {
+    Q_wad { val: a.val.mul(SCALE.to_int()).sqrt() }
+}
+
+#[spec_only, ext(pure)]
+public fun pow(x: Q_wad, n: Integer): Q_wad {
+    Q_wad { val: std::macros::q_pow!(x.val, n, SCALE.to_int()) }
+}
+
+// === Comparisons ===
+
+#[spec_only, ext(pure)]
+public fun lt(a: Q_wad, b: Q_wad): bool { a.val.lt(b.val) }
+
+#[spec_only, ext(pure)]
+public fun gt(a: Q_wad, b: Q_wad): bool { a.val.gt(b.val) }
+
+#[spec_only, ext(pure)]
+public fun lte(a: Q_wad, b: Q_wad): bool { a.val.lte(b.val) }
+
+#[spec_only, ext(pure)]
+public fun gte(a: Q_wad, b: Q_wad): bool { a.val.gte(b.val) }
+
+#[spec_only, ext(pure)]
+public fun min(a: Q_wad, b: Q_wad): Q_wad {
+    if (a.lt(b)) a else b
+}
+
+#[spec_only, ext(pure)]
+public fun max(a: Q_wad, b: Q_wad): Q_wad {
+    if (a.gt(b)) a else b
+}
+
+// === Rounding / Conversion ===
+
+#[spec_only, ext(pure)]
+public fun floor(q: Q_wad): Integer {
+    q.val.div(SCALE.to_int())
+}
+
+#[spec_only, ext(pure)]
+public fun ceil(q: Q_wad): Integer {
+    q.val.div_round_up(SCALE.to_int())
+}
+
+#[spec_only, ext(pure)]
+public fun round(q: Q_wad): Integer {
+    q.val.add(HALF_SCALE.to_int()).div(SCALE.to_int())
+}
+
+#[spec_only, ext(pure)]
+public fun to_int(q: Q_wad): Integer { floor(q) }
+
+#[spec_only, ext(pure)]
+public fun to_real(q: Q_wad): Real {
+    q.val.to_real().div(SCALE.to_real())
+}
+
+// === Predicates ===
+
+#[spec_only]
+public macro fun is_zero($q: Q_wad): bool {
+    let q = $q;
+    q.val == std::integer::zero!()
+}
+
+#[spec_only, ext(pure)]
+public fun is_pos(q: Q_wad): bool { q.val.is_pos() }
+
+#[spec_only, ext(pure)]
+public fun is_neg(q: Q_wad): bool { q.val.is_neg() }
+
+#[spec_only, ext(pure)]
+public fun is_int(q: Q_wad): bool {
+    q.val.mod(SCALE.to_int()) == 0u64.to_int()
+}
+
+#[spec_only, ext(pure)]
+public fun in_range_u64(x: Q_wad): bool {
+    !x.is_neg() && x.val.lte(0xFFFF_FFFF_FFFF_FFFFu64.to_int())
+}
+
+#[spec_only, ext(pure)]
+public fun in_range_u128(x: Q_wad): bool {
+    !x.is_neg() && x.val.lte(
+        0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFFu128.to_int(),
+    )
+}
+
+#[spec_only, ext(pure)]
+public fun in_range_u256(x: Q_wad): bool {
+    !x.is_neg() && x.val.lte(
+        0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFFu256
+            .to_int(),
+    )
+}

--- a/crates/sui-framework/packages/move-stdlib/sources/real.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/real.move
@@ -101,3 +101,7 @@ public use fun std::q32::from_real as Real.to_q32;
 public use fun std::q64::from_real as Real.to_q64;
 #[spec_only]
 public use fun std::q128::from_real as Real.to_q128;
+#[spec_only]
+public use fun std::q_wad::from_real as Real.to_q_wad;
+#[spec_only]
+public use fun std::q_ray::from_real as Real.to_q_ray;

--- a/crates/sui-framework/packages/move-stdlib/sources/u128.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/u128.move
@@ -134,3 +134,7 @@ public use fun std::q32::from_u128 as u128.to_q32;
 public use fun std::q64::from_u128 as u128.to_q64;
 #[spec_only]
 public use fun std::q128::from_u128 as u128.to_q128;
+#[spec_only]
+public use fun std::q_wad::from_u128 as u128.to_q_wad;
+#[spec_only]
+public use fun std::q_ray::from_u128 as u128.to_q_ray;

--- a/crates/sui-framework/packages/move-stdlib/sources/u16.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/u16.move
@@ -115,3 +115,7 @@ public use fun std::q32::from_u16 as u16.to_q32;
 public use fun std::q64::from_u16 as u16.to_q64;
 #[spec_only]
 public use fun std::q128::from_u16 as u16.to_q128;
+#[spec_only]
+public use fun std::q_wad::from_u16 as u16.to_q_wad;
+#[spec_only]
+public use fun std::q_ray::from_u16 as u16.to_q_ray;

--- a/crates/sui-framework/packages/move-stdlib/sources/u256.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/u256.move
@@ -111,3 +111,7 @@ public use fun std::q32::from_u256 as u256.to_q32;
 public use fun std::q64::from_u256 as u256.to_q64;
 #[spec_only]
 public use fun std::q128::from_u256 as u256.to_q128;
+#[spec_only]
+public use fun std::q_wad::from_u256 as u256.to_q_wad;
+#[spec_only]
+public use fun std::q_ray::from_u256 as u256.to_q_ray;

--- a/crates/sui-framework/packages/move-stdlib/sources/u32.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/u32.move
@@ -122,3 +122,7 @@ public use fun std::q32::from_u32 as u32.to_q32;
 public use fun std::q64::from_u32 as u32.to_q64;
 #[spec_only]
 public use fun std::q128::from_u32 as u32.to_q128;
+#[spec_only]
+public use fun std::q_wad::from_u32 as u32.to_q_wad;
+#[spec_only]
+public use fun std::q_ray::from_u32 as u32.to_q_ray;

--- a/crates/sui-framework/packages/move-stdlib/sources/u64.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/u64.move
@@ -128,4 +128,8 @@ public use fun std::q32::from_u64 as u64.to_q32;
 public use fun std::q64::from_u64 as u64.to_q64;
 #[spec_only]
 public use fun std::q128::from_u64 as u64.to_q128;
+#[spec_only]
+public use fun std::q_wad::from_u64 as u64.to_q_wad;
+#[spec_only]
+public use fun std::q_ray::from_u64 as u64.to_q_ray;
 

--- a/crates/sui-framework/packages/move-stdlib/sources/u8.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/u8.move
@@ -110,3 +110,7 @@ public use fun std::q32::from_u8 as u8.to_q32;
 public use fun std::q64::from_u8 as u8.to_q64;
 #[spec_only]
 public use fun std::q128::from_u8 as u8.to_q128;
+#[spec_only]
+public use fun std::q_wad::from_u8 as u8.to_q_wad;
+#[spec_only]
+public use fun std::q_ray::from_u8 as u8.to_q_ray;


### PR DESCRIPTION
Add decimal-scaled fixed-point types for DeFi specifications:
- Q_wad: 10^18 scale (WAD), with in_range_u64/u128/u256 predicates
- Q_ray: 10^27 scale (RAY), with in_range_u128/u256 predicates

Both follow the same API pattern as Q32/Q64/Q128 (construction, arithmetic, comparisons, rounding, predicates). Extension methods (to_q_wad, to_q_ray) added to all numeric types.